### PR TITLE
Fix error when trying to run in docker

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const stockXAPI = require('./src/classes/Stockx');
+const stockXAPI = require('./src/classes/stockx.js');
 
 module.exports = stockXAPI;


### PR DESCRIPTION
Was getting this error when running in docker because the import is case sensitive:

```
> node index.js

node:internal/modules/cjs/loader:944
  throw err;
  ^

Error: Cannot find module './src/classes/Stockx'
Require stack:
- /usr/src/app/node_modules/stockx-api/index.js
- /usr/src/app/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:941:15)
    at Function.Module._load (node:internal/modules/cjs/loader:774:27)
    at Module.require (node:internal/modules/cjs/loader:1013:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.<anonymous> (/usr/src/app/node_modules/stockx-api/index.js:1:19)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Module.require (node:internal/modules/cjs/loader:1013:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/usr/src/app/node_modules/stockx-api/index.js',
    '/usr/src/app/index.js'
  ]
}
```