### PR TITLE
fixed parsing of searchOnlyApiKey;

### DIFF
--- a/src/api/scrapers/fetchapikey.js
+++ b/src/api/scrapers/fetchapikey.js
@@ -27,15 +27,21 @@ module.exports = async (options = {}) => {
 
     checkRes(res);
 
-    let globalConstantString, constantsObject;
-    
+    const parseError = new Error("Failed to parse API key for search");
+    let searchOnlyApiKeyString;
     try {
-        globalConstantString = res.body.split('window.globalConstants = ')[1].split('</script>')[0].trim();
-        constantsObject = globalConstantString.endsWith(';') ? parseJSON(globalConstantString.slice(0, globalConstantString.length - 1)) : JSON.parse(globalConstantString);
-    }
-    catch(err){
-        throw new Error("Failed to parse API key for search");
-    };
+        let splittedBodyContent = res.body.split('window.searchOnlyApiKey = ');
 
-    return constantsObject.search.SEARCH_ONLY_API_KEY;
+        if (splittedBodyContent.length < 2) {
+            throw parseError
+        }
+
+        splittedBodyContent = splittedBodyContent[1].split("';")
+        searchOnlyApiKeyString = splittedBodyContent[0].replace("'", "").trim();
+    } catch (err) {
+        console.error(err)
+        throw parseError;
+    }
+
+    return searchOnlyApiKeyString;
 };

--- a/src/classes/stockx.js
+++ b/src/classes/stockx.js
@@ -36,6 +36,7 @@ module.exports = class StockX {
      * @param {string} query - The query string to search for 
      * @param {Object=} options
      * @param {Number=} options.limit - The limit on how many products to return at max 
+     * @deprecated Seems like the api blocks this endpoint now. Use newSearchProducts()
      */
     async searchProducts(query, options = {}){
         //Search products and return them


### PR DESCRIPTION
Due to the fact, that `searchProducts()` is not working anymore (at least for me) i had to switch to `newSearchProducts()`. There i saw that the parsing of the search only api key does not work anymore.