### PR TITLE
Main function import typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const stockXAPI = require('./src/classes/Stockx');
+const stockXAPI = require('./src/classes/stockx');
 
 module.exports = stockXAPI;


### PR DESCRIPTION
Error: Cannot find module './src/classes/Stockx'
fixed by changing the import path