### PR TITLE
Fix typo error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const stockXAPI = require('./src/classes/stockx');
+const stockXAPI = require('./src/classes/stockx.js');
 
 module.exports = stockXAPI;


### PR DESCRIPTION
There is a typo with this line:
https://github.com/matthew1232/stockx-api/blob/4aa586aa9ab8c2525098df5e16a48cdad0fdf6c6/index.js#L1

Instead of saying `stockx.js` it says `stockx`. This results in a terminating error (I've tested) because there is no file named "stockx" in [this folder](https://github.com/matthew1232/stockx-api/tree/f68cd8c03b116e838059ef6f3627c20d129771e4/src/classes), only one named "stock.js". This pull request fixes the typo. :smiley: